### PR TITLE
SMTP: Cc and Bcc are recipients too

### DIFF
--- a/src/Network/HaskellNet/SMTP.hs
+++ b/src/Network/HaskellNet/SMTP.hs
@@ -347,10 +347,11 @@ sendMimeMail' to from subject plainBody htmlBody attachments con = do
 sendMimeMail2 :: Mail -> SMTPConnection -> IO ()
 sendMimeMail2 mail con = do
     let (Address _ from) = mailFrom mail
-        tos = map (T.unpack . addressEmail) $ mailTo mail
-    when (null tos) $ fail "no receiver specified."
+        recps = map (T.unpack . addressEmail)
+                     $ (mailTo mail ++ mailCc mail ++ mailBcc mail)
+    when (null recps) $ fail "no receiver specified."
     renderedMail <- renderMail' mail
-    sendMail (T.unpack from) tos (lazyToStrict renderedMail) con
+    sendMail (T.unpack from) recps (lazyToStrict renderedMail) con
 
 -- haskellNet uses strict bytestrings
 -- TODO: look at making haskellnet lazy


### PR DESCRIPTION
In SMTP, the RCPT should also receive the Cc: and Bcc: lists of the E-Mail, otherwise, the mail is only sent to the recipients in the To: list, because servers don't do the extra work of inferring the additional recipients from these headers.

Issue discovered while passing an non empty list in Cc and wondering why the messages did not reach the other side.