### PR TITLE
Basic IDLE command implementation

### DIFF
--- a/src/Network/HaskellNet/BSStream.hs
+++ b/src/Network/HaskellNet/BSStream.hs
@@ -28,6 +28,8 @@ data BSStream =
              -- ^Close the stream.
              , bsIsOpen :: IO Bool
              -- ^Is the stream open?
+             , bsWaitForInput :: Int -> IO Bool
+             -- ^Is data available?
              }
 
 -- |Build a byte string stream which operates on a 'Handle'.
@@ -41,4 +43,5 @@ handleToStream h =
                  op <- hIsOpen h
                  if op then (hClose h) else return ()
              , bsIsOpen = hIsOpen h
+             , bsWaitForInput = hWaitForInput h
              }


### PR DESCRIPTION
These patches allow to issue IDLE command.

Idle works in one-shot mode, the command terminates either on timeout or on the server reponse.
The timeout is set in milliseconds.