### PR TITLE
Strip carriage returns from the end of lines before sending

### DIFF
--- a/src/Network/HaskellNet/SMTP.hs
+++ b/src/Network/HaskellNet/SMTP.hs
@@ -192,9 +192,12 @@ sendCommand (SMTPC conn _) (DATA dat) =
     do bsPutCrLf conn $ BS.pack "DATA"
        (code, _) <- parseResponse conn
        unless (code == 354) $ fail "this server cannot accept any data."
-       mapM_ sendLine $ BS.lines dat ++ [BS.pack "."]
+       mapM_ (sendLine . stripCR) $ BS.lines dat ++ [BS.pack "."]
        parseResponse conn
     where sendLine = bsPutCrLf conn
+          stripCR bs = case BS.unsnoc bs of
+                         Just (line, '\r') -> line
+                         _                 -> bs
 sendCommand (SMTPC conn _) (AUTH LOGIN username password) =
     do bsPutCrLf conn command
        (_, _) <- parseResponse conn


### PR DESCRIPTION
This fixes an issue reported on haskell-cafe[1], where spurious
linefeeds will find their way into an email sent with HaskellNet.  The
reason is that we use ByteString's `lines` function to split the source
ByteString into lines, and then join those lines together again with
'\r\n' -- but `lines` only splits on '\n', so if the source ByteString
already used '\r\n'-style linefeeds the resulting mail ends up with
extra carriage returns.

This commit takes the simplest approach to solving this: after splitting
up the lines on '\n', we check if any of the resulting lines end in
'\r', and if they do we strip it.  This covers us for '\n' and '\r\n'
linefeeds, but not for '\r' linefeeds.

There may be a better way to do this, such as the portable-lines package[2],
but I wasn't sure about incurring another dependency for such a tiny
feature, so I'm submitting the simplest possible fix for now and open to
discussion about better approaches if anybody thinks this won't suffice.

[1]: http://article.gmane.org/gmane.comp.lang.haskell.cafe/120647
[2]: https://hackage.haskell.org/package/portable-lines