### PR TITLE
Fix some parsing bugs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+HEAD
+----
+
+ - IMAP: Add parenthesis around the multiple headers in fetchHeaderFields and fetchHeaderFieldsNot
+
 0.5.1 (2016-05-05)
 ------------------
 

--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -377,14 +377,14 @@ fetchSize conn uid =
 fetchHeaderFields :: IMAPConnection
                   -> UID -> [String] -> IO ByteString
 fetchHeaderFields conn uid hs =
-    do lst <- fetchByString conn uid ("BODY[HEADER.FIELDS "++unwords hs++"]")
+    do lst <- fetchByString conn uid ("BODY[HEADER.FIELDS ("++unwords hs++")]")
        return $ maybe BS.empty BS.pack $
-              lookup' ("BODY[HEADER.FIELDS "++unwords hs++"]") lst
+              lookup' ("BODY[HEADER.FIELDS ("++unwords hs++")]") lst
 
 fetchHeaderFieldsNot :: IMAPConnection
                      -> UID -> [String] -> IO ByteString
 fetchHeaderFieldsNot conn uid hs =
-    do let fetchCmd = "BODY[HEADER.FIELDS.NOT "++unwords hs++"]"
+    do let fetchCmd = "BODY[HEADER.FIELDS.NOT ("++unwords hs++")]"
        lst <- fetchByString conn uid fetchCmd
        return $ maybe BS.empty BS.pack $ lookup' fetchCmd lst
 

--- a/src/Network/HaskellNet/IMAP/Parsers.hs
+++ b/src/Network/HaskellNet/IMAP/Parsers.hs
@@ -323,7 +323,7 @@ pFetchLine =
        num <- many1 digit
        string " FETCH" >> spaces
        char '('
-       pairs <- pPair `sepBy` space
+       pairs <- pPair `sepBy` (spaces1 <|> crlfP)
        char ')'
        crlfP
        return $ Right $ (read num, pairs)
@@ -339,7 +339,7 @@ pFetchLine =
                           <|> (do char '{'
                                   num <- many1 digit >>= return . read
                                   char '}' >> crlfP
-                                  sequence $ replicate num anyChar)
+                                  count (num - 2) anyChar)
                           <|> (do char '"'
                                   v <- noneOf "\"" `manyTill` char '"'
                                   return ("\""++v++"\""))


### PR DESCRIPTION
Two bugs addressed:
- fetchHeaderFields didn't wrap the header names with parenthesis thus it was broken with multiple values
- Attempt to fix the Exchange compatibility bug (**works but not sure it is safe enough**)

@fegu Could you double check please ?
