### PR TITLE
prevent unsafe use of BS.{init,last}

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -165,7 +165,8 @@ getResponse s = unlinesCRLF <$> getLs
           getLs =
               do l <- strip <$> bsGetLine s
                  case () of
-                   _ | isLiteral l ->  do l' <- getLiteral l (getLitLen l)
+                   _ | BS.null l -> return [l]
+                     | isLiteral l ->  do l' <- getLiteral l (getLitLen l)
                                           ls <- getLs
                                           return (l' : ls)
                      | isTagged l -> (l:) <$> getLs


### PR DESCRIPTION
It's possible (though rare) that we can receive an empty stream in `getResponse` causing `isLiteral` to throw `empty ByteString` exception.

Fixed by ensuring a non-empty string prior to calling `isLiteral` (and `isTagged`).

Also did a bit syntactic improvement (in my opinion).