### PR TITLE
Allow mime-mail starting with v0.5

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -56,5 +56,5 @@ Library
     cryptohash,
     base64-string,
     old-time,
-    mime-mail >= 0.4.7 && < 0.5,
+    mime-mail >= 0.4.7 && < 0.6,
     text


### PR DESCRIPTION
Hello, I became a maintainer of https://github.com/snoyberg/mime-mail and released a new version that changes API but the functions you use remained the same and will be in whole `0.5.X`. Could you please update your package? Or please remove the dependency when it is just in the example...

https://github.com/jtdaugherty/HaskellNet/blob/master/example/smtp.hs#L6

