### PR TITLE
Allow for RCPT to return 251

### DIFF
--- a/src/Network/HaskellNet/SMTP.hs
+++ b/src/Network/HaskellNet/SMTP.hs
@@ -149,18 +149,18 @@ connectSMTP :: String     -- ^ name of the server
             -> IO SMTPConnection
 connectSMTP = flip connectSMTPPort 25
 
-tryCommand :: SMTPConnection -> Command -> Int -> ReplyCode
+tryCommand :: SMTPConnection -> Command -> Int -> [ReplyCode]
            -> IO ByteString
-tryCommand conn cmd tries expectedReply = do
+tryCommand conn cmd tries expectedReplies = do
   (code, msg) <- sendCommand conn cmd
   case () of
-    _ | code == expectedReply   -> return msg
+    _ | code `elem` expectedReplies   -> return msg
     _ | tries > 1               ->
-          tryCommand conn cmd (tries - 1) expectedReply
+          tryCommand conn cmd (tries - 1) expectedReplies
       | otherwise               -> do
           bsClose (bsstream conn)
           fail $ "cannot execute command " ++ show cmd ++
-                 ", expected reply code " ++ show expectedReply ++
+                 ", expected reply code any of " ++ show expectedReplies ++
                  ", but received " ++ show code ++ " " ++ BS.unpack msg
 
 -- | create SMTPConnection from already connected Stream
@@ -171,7 +171,7 @@ connectStream st =
               do bsClose st
                  fail "cannot connect to the server"
        senderHost <- getHostName
-       msg <- tryCommand (SMTPC st []) (EHLO senderHost) 3 250
+       msg <- tryCommand (SMTPC st []) (EHLO senderHost) 3 [250]
        return (SMTPC st (tail $ BS.lines msg))
 
 parseResponse :: BSStream -> IO (ReplyCode, ByteString)
@@ -283,7 +283,7 @@ sendMail sender receivers dat conn = do
                  return ()
   where
     -- Try the command once and @fail@ if the response isn't 250.
-    sendAndCheck cmd = tryCommand conn cmd 1 250
+    sendAndCheck cmd = tryCommand conn cmd 1 [250, 251]
 
 -- | doSMTPPort open a connection, and do an IO action with the
 -- connection, and then close it.


### PR DESCRIPTION
This allows SMTP servers sending information-updates without HaskellNet failing on that: https://tools.ietf.org/html/rfc5321#section-3.4