### PR TITLE
Check whether a ByteString is null before calling `last` on it

### DIFF
--- a/src/Network/HaskellNet/IMAP.hs
+++ b/src/Network/HaskellNet/IMAP.hs
@@ -180,7 +180,8 @@ getResponse s = unlinesCRLF <$> getLs
                    then getLiteral l' (getLitLen l2)
                    else return l'
           crlfStr = BS.pack "\r\n"
-          isLiteral l = BS.last l == '}' &&
+          isLiteral l = not (BS.null l) &&
+                        BS.last l == '}' &&
                         BS.last (fst (BS.spanEnd isDigit (BS.init l))) == '{'
           getLitLen = read . BS.unpack . snd . BS.spanEnd isDigit . BS.init
           isTagged l = BS.head l == '*' && BS.head (BS.tail l) == ' '


### PR DESCRIPTION
The main codepath does check for null before invoking isLiteral, but the other one (`isLiteral l2` above) doesn't seem to