### PR TITLE
Make pFetchLine parser more lenient

### DIFF
--- a/src/Network/HaskellNet/IMAP/Parsers.hs
+++ b/src/Network/HaskellNet/IMAP/Parsers.hs
@@ -324,8 +324,7 @@ pFetchLine =
        num <- many1 digit
        string " FETCH" >> spaces
        char '('
-       pairs <- pPair `sepBy` space
-       char ')'
+       pairs <- pPair `manyTill` char ')'
        crlfP
        return $ Right $ (read num, pairs)
     where pPair = do key <- (do k  <- anyChar `manyTill` char '['
@@ -345,6 +344,7 @@ pFetchLine =
                                   v <- noneOf "\"" `manyTill` char '"'
                                   return ("\""++v++"\""))
                           <|> many1 atomChar
+                     spaces
                      return (key, value)
           pParen = (do char '"'
                        v <- noneOf "\"" `manyTill` char '"'


### PR DESCRIPTION
Separator can now be 0 spaces or more than 1 space

This fixes #69