### PR TITLE
use cryptohash-md5 instead of deprecated cryptohash

### DIFF
--- a/HaskellNet.cabal
+++ b/HaskellNet.cabal
@@ -71,7 +71,7 @@ Library
     bytestring >=0.10.2,
     pretty,
     array,
-    cryptohash >=0.6,
+    cryptohash-md5,
     base64-string,
     old-time,
     mime-mail >= 0.4.7 && < 0.6,


### PR DESCRIPTION
Tiny PR to replace cryptohash by cryptohash-md5.

[cryptohash](https://hackage.haskell.org/package/cryptohash) is deprecated, and HaskellNet only uses a small piece of it. [cryptohash-md5](https://hackage.haskell.org/package/cryptohash-md5) solves both issues.